### PR TITLE
Fixes syntax errors preventing loading _nest on Norns

### DIFF
--- a/grid.lua
+++ b/grid.lua
@@ -1602,7 +1602,7 @@ _grid.number.param = function(s, id)
         })
     else err(t) end; return s
 end
-_grid.toggle.param = = function(s, id)
+_grid.toggle.param = function(s, id)
     local p,t = gp(id), '_grid.toggle'
 
     if p.t == pt.binary then

--- a/norns.lua
+++ b/norns.lua
@@ -855,7 +855,7 @@ _key.option.param = function(s, id)
         })
     else err(t) end; return s
 end
-_key.toggle.param = = function(s, id)
+_key.toggle.param = function(s, id)
     local p,t = gp(id), '_key.toggle'
 
     if p.t == pt.binary then


### PR DESCRIPTION
Ran into this issue because of the submodule dependency in the `_nest` Norns library. Looks like this might be fixed in your 1.2 branch, so do with this what you please!

Thanks for your work on this project!